### PR TITLE
Ambiguous home directory caused config / log issues 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ APP_SUPPORT_DIR="$HOME/.locations" #/Library/Application Support/LocationChanger
 sudo -v
 
 echo "Copying script and making it executable"
-sudo cat "$SCRIPT_NAME" | sed -e 's%$HOME%'$HOME'%g' -e 's%${HOME}%'$HOME'%g' > "$INSTALL_DIR"
+sudo cat "$SCRIPT_NAME" | sed -e 's%$HOME%'$HOME'%g' -e 's%${HOME}%'$HOME'%g' > "$INSTALL_DIR/$SCRIPT_NAME"
 
 sudo chmod +x ${SCRIPT_NAME}
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ sudo -v
 echo "Copying script and making it executable"
 sudo cat "$SCRIPT_NAME" | sed -e 's%$HOME%'$HOME'%g' -e 's%${HOME}%'$HOME'%g' > "$INSTALL_DIR/$SCRIPT_NAME"
 
-sudo chmod +x ${SCRIPT_NAME}
+sudo chmod +x "$INSTALL_DIR/${SCRIPT_NAME}"
 
 # generate a default config file if it doesn't exists
 function copyConfig() {

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ APP_SUPPORT_DIR="$HOME/.locations" #/Library/Application Support/LocationChanger
 sudo -v
 
 echo "Copying script and making it executable"
-sudo cp "$SCRIPT_NAME" "$INSTALL_DIR"
+sudo cat "$SCRIPT_NAME" | sed -e 's%$HOME%'$HOME'%g' -e 's%${HOME}%'$HOME'%g' > "$INSTALL_DIR"
 
 sudo chmod +x ${SCRIPT_NAME}
 


### PR DESCRIPTION
After installing I noticed that it was not logging. Tracked it down to it not having $HOME defined when run via launchd. I changed the install.sh to hardcode the value of $HOME during the installation. I also noticed that it was changing the permission of the initial copy to executable not the installed copy. 